### PR TITLE
Fix NPE if the NBT data didn't contain a WEOrigin position

### DIFF
--- a/src/main/java/com/davixdevelop/schem2obj/schematic/Schematic.java
+++ b/src/main/java/com/davixdevelop/schem2obj/schematic/Schematic.java
@@ -110,9 +110,9 @@ public class Schematic implements java.io.Serializable {
         short length = ((ShortTag)nbtData.get("Length")).getValue();
         short height = ((ShortTag)nbtData.get("Height")).getValue();
 
-        int offsetX = ((IntTag)nbtData.get("WEOriginX")).getValue();
-        int offsetY = ((IntTag)nbtData.get("WEOriginY")).getValue();
-        int offsetZ = ((IntTag)nbtData.get("WEOriginZ")).getValue();
+        int offsetX = getOrDefault(((IntTag)nbtData.get("WEOriginX")), 0);
+        int offsetY = getOrDefault(((IntTag)nbtData.get("WEOriginY")), 0);
+        int offsetZ = getOrDefault(((IntTag)nbtData.get("WEOriginZ")), 0);
 
         byte[] blockId = ((ByteArrayTag)nbtData.get("Blocks")).getValue();
         byte[] blockData = ((ByteArrayTag)nbtData.get("Data")).getValue();
@@ -194,5 +194,12 @@ public class Schematic implements java.io.Serializable {
         stream.close();
 
         return new Schematic(blocks, data, width, length, height, offsetX, offsetY, offsetZ, tileEntities, entities);
+    }
+
+    private static <VALUE, TAG extends Tag<VALUE>> VALUE getOrDefault(TAG tag, VALUE defaultValue) {
+        if (tag == null) {
+            return defaultValue;
+        }
+        return tag.getValue();
     }
 }


### PR DESCRIPTION
Some of the schematics I've been testing with are missing this tag, it now defaults to `(0, 0, 0)`

Let me know if you want me to move `getOrDefault` to a specific util class, though I couldn't find one related to NBT at a glance