### PR TITLE
Optimise HashedDoubleList to use BigDecimal rounding instead of text based hashing

### DIFF
--- a/src/main/java/com/davixdevelop/schem2obj/models/HashedDoubleList.java
+++ b/src/main/java/com/davixdevelop/schem2obj/models/HashedDoubleList.java
@@ -2,69 +2,85 @@ package com.davixdevelop.schem2obj.models;
 
 import com.davixdevelop.schem2obj.util.ArrayUtility;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Locale;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.util.*;
 
 /**
- * A Array Double List that uses a Map to store the indexes to each element in the list
+ * An Array Double List that uses a Map to store the indexes to each element in the list
+ *
  * @author DavixDevelop
  */
 public class HashedDoubleList {
-    ArrayList<Double[]> list;
-    HashMap<String, Integer> index;
+    private static final int DEFAULT_PRECISION = 6;
 
+    private final ArrayList<Double[]> list;
+    private final HashMap<CachedHashArray, Integer> index;
 
-    public HashedDoubleList(){
+    private final MathContext context;
+
+    public HashedDoubleList() {
+        this(DEFAULT_PRECISION);
+    }
+
+    public HashedDoubleList(int hashPrecision) {
+        this.context = new MathContext(hashPrecision);
         list = new ArrayList<>();
         index = new HashMap<>();
     }
 
-    public boolean containsKey(Double... values){
-        return index.containsKey(createKey(values));
+    public boolean containsKey(Double... values) {
+        return index.containsKey(new CachedHashArray(values));
     }
 
-    public int put(Double... values){
-        list.add(ArrayUtility.cloneArray(values));
-        index.put(createKey(values), list.size() - 1);
+    public int put(Double... values) {
+        Double[] clonedArray = ArrayUtility.cloneArray(values);
+        list.add(clonedArray);
+        index.put(new CachedHashArray(clonedArray), list.size() - 1);
 
         return list.size() - 1;
     }
 
-    public Double[] get(Integer index){
+    public Double[] get(Integer index) {
         return list.get(index);
     }
 
-    public Integer getIndex(Double... values){
-        return index.get(createKey(values));
-    }
-
-    public ArrayList<Double[]> toList(){
+    public ArrayList<Double[]> toList() {
         return list;
     }
 
-    public int size(){
+    public int size() {
         return list.size();
     }
 
-    private String createKey(Double... values){
-        StringBuilder key = new StringBuilder();
-        boolean first = true;
-        for(Double val : values){
-            key.append(String.format(Locale.ROOT, "%s%.6f", (first) ? "" : ":", val));
-            first = false;
+    private class CachedHashArray {
+        final Double[] internalArray;
+        private final int cachedHash;
+
+        public CachedHashArray(Double[] array) {
+            this.internalArray = array;
+
+            int result = 1;
+
+            for (Double element : array) {
+                result = 31 * result + (element == null ? 0 :
+                        new BigDecimal(element).round(HashedDoubleList.this.context).hashCode());
+            }
+
+            this.cachedHash = result;
         }
 
-        return key.toString();
-    }
-
-    private String getKey(Integer index){
-        for(String key : this.index.keySet()){
-            if(index.equals(this.index.get(key)))
-                return key;
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            CachedHashArray that = (CachedHashArray) o;
+            return Arrays.equals(internalArray, that.internalArray);
         }
 
-        return null;
+        @Override
+        public int hashCode() {
+            return this.cachedHash;
+        }
     }
 }

--- a/src/main/java/com/davixdevelop/schem2obj/util/ArrayUtility.java
+++ b/src/main/java/com/davixdevelop/schem2obj/util/ArrayUtility.java
@@ -91,9 +91,6 @@ public class ArrayUtility {
         if(org == null)
             return null;
 
-        Double[] clone = new Double[org.length];
-        clone = Arrays.copyOf(org, org.length);
-
-        return clone;
+        return Arrays.copyOf(org, org.length);
     }
 }


### PR DESCRIPTION
BigDecimal is used instead of a more janky rounding method to attempt to mitigate the inherent problems with having floating point keys in a map (see [this stackoverflow answer](https://stackoverflow.com/a/580928)).

(also added an unrelated small optimisation to arrayutil)